### PR TITLE
Updating Yugabytedb version to the latest docker image

### DIFF
--- a/src/test/resources/docker/docker-compose.yml
+++ b/src/test/resources/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.3'
 services:
 
   yugabytedb-2.6:
-    image: yugabytedb/yugabyte:latest
+    image: yugabytedb/yugabyte:2.9.0.0-b4
     command:  bin/yugabyted start --daemon=false --initial_scripts_dir /docker-entrypoint-initdb.d
     restart: always
     ports:


### PR DESCRIPTION
Image yugabytedb/yugabyte:latest does not contain the latest image and was modified 5 months ago. 