### PR TITLE
Add support for advanced test harness suite

### DIFF
--- a/src/main/java/liquibase/ext/yugabytedb/sqlgenerator/AddUniqueConstraintGeneratorYugabyteDB.java
+++ b/src/main/java/liquibase/ext/yugabytedb/sqlgenerator/AddUniqueConstraintGeneratorYugabyteDB.java
@@ -1,0 +1,40 @@
+package liquibase.ext.yugabytedb.sqlgenerator;
+
+import liquibase.database.Database;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.AddUniqueConstraintGenerator;
+import liquibase.statement.core.AddUniqueConstraintStatement;
+import liquibase.structure.core.Index;
+
+public class AddUniqueConstraintGeneratorYugabyteDB extends AddUniqueConstraintGenerator {
+
+    @Override
+    public Sql[] generateSql(AddUniqueConstraintStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        String sql;
+        if (statement.getConstraintName() == null) {
+            sql = String.format("ALTER TABLE %s ADD UNIQUE" + (statement.isClustered() ? " CLUSTERED " : " ") + "(%s)"
+                    , database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName())
+                    , database.escapeColumnNameList(statement.getColumnNames())
+            );
+        } else {
+            sql = String.format("ALTER TABLE %s ADD CONSTRAINT %s UNIQUE" + (statement.isClustered() ? " CLUSTERED " : " ") + "(%s)"
+                    , database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName())
+                    , database.escapeConstraintName(statement.getConstraintName())
+                    , database.escapeColumnNameList(statement.getColumnNames())
+            );
+        }
+        boolean isInUsingIndexClause = false;
+
+        if (statement.getForIndexName() != null) {
+            sql += " USING INDEX ";
+            sql += database.escapeObjectName(statement.getForIndexCatalogName(), statement.getForIndexSchemaName(),
+                    statement.getForIndexName(), Index.class);
+            isInUsingIndexClause = true;
+        }
+        return new Sql[]{
+                new UnparsedSql(sql, getAffectedUniqueConstraint(statement))
+        };
+    }
+}

--- a/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
+++ b/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
@@ -1,3 +1,4 @@
 liquibase.ext.yugabytedb.sqlgenerator.DropPrimaryKeyGeneratorYugabyteDB
 liquibase.ext.yugabytedb.sqlgenerator.AlterSequenceGeneratorYugabyteDB
 liquibase.ext.yugabytedb.sqlgenerator.RenameSequenceGeneratorYugabyteDB
+liquibase.ext.yugabytedb.sqlgenerator.AddUniqueConstraintGeneratorYugabyteDB

--- a/src/test/resources/liquibase/harness/generateChangelog/expectedChangeLog/yugabytedb/createTable.sql
+++ b/src/test/resources/liquibase/harness/generateChangelog/expectedChangeLog/yugabytedb/createTable.sql
@@ -1,0 +1,1 @@
+CREATE TABLE "test_table_xml" ("test_column" INTEGER);

--- a/src/test/resources/liquibase/harness/snapshot/expectedSnapshot/yugabytedb/addColumn.json
+++ b/src/test/resources/liquibase/harness/snapshot/expectedSnapshot/yugabytedb/addColumn.json
@@ -1,0 +1,51 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Table": [
+        {
+          "table": {
+            "name": "test_table"
+          }
+        }
+      ],
+      "liquibase.structure.core.Column": [
+        {
+          "column": {
+            "name": "test_column",
+            "nullable": true,
+            "type": {
+              "typeName": "INT4"
+            }
+          }
+        },
+        {
+          "column": {
+            "name": "varcharColumn",
+            "nullable": true,
+            "type": {
+              "typeName": "VARCHAR"
+            }
+          }
+        },
+        {
+          "column": {
+            "name": "intColumn",
+            "nullable": true,
+            "type": {
+              "typeName": "INT4"
+            }
+          }
+        },
+        {
+          "column": {
+            "name": "dateColumn",
+            "nullable": true,
+            "type": {
+              "typeName": "DATE"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/liquibase/harness/snapshot/expectedSnapshot/yugabytedb/createTable.json
+++ b/src/test/resources/liquibase/harness/snapshot/expectedSnapshot/yugabytedb/createTable.json
@@ -1,0 +1,23 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Table": [
+        {
+          "table": {
+            "name": "snapshot_test_table"
+          }
+        }
+      ],
+      "liquibase.structure.core.Column": [
+        {
+          "column": {
+            "name": "snapshot_test_column",
+            "type": {
+              "typeName": "INT4"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/liquibase/harness/snapshot/expectedSnapshot/yugabytedb/createView.json
+++ b/src/test/resources/liquibase/harness/snapshot/expectedSnapshot/yugabytedb/createView.json
@@ -1,0 +1,21 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Table": [
+        {
+          "table": {
+            "name": "view_table"
+          }
+        }
+      ],
+      "liquibase.structure.core.View": [
+        {
+          "view": {
+            "definition": "SELECT view_table.test_column\n   FROM view_table;",
+            "name": "test_view"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/test/resources/liquibase/harness/snapshot/expectedSnapshot/yugabytedb/snapshotCaalogAndSchema.json
+++ b/src/test/resources/liquibase/harness/snapshot/expectedSnapshot/yugabytedb/snapshotCaalogAndSchema.json
@@ -1,0 +1,20 @@
+{
+  "snapshot": {
+    "objects": {
+      "liquibase.structure.core.Catalog": [
+        {
+          "catalog": {
+            "name": "lbcat"
+          }
+        }
+      ],
+      "liquibase.structure.core.Schema": [
+        {
+          "schema": {
+            "name": "public"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Addressed the test failures in the AdvancedExtensionHarnessSuite and added support accordingly.

Changes made:

- Added a AddUniqueKeyConstraintGenerator implementation - Deferrable Unique Constraint are not supported in Yugabytedb. Modified the Sql Generatorso that it generates the adding of unique constraint without it being deferrable. 
- Added expectedSql and expeceted changelogs.