### PR TITLE
DAT-14350 Devops: Extension github actions fail for external contributors

### DIFF
--- a/.github/workflows/lth.yml
+++ b/.github/workflows/lth.yml
@@ -12,7 +12,6 @@ on:
       - main
 
 jobs:
-#  liquibase-test-harness:
-#    uses: liquibase/build-logic/.github/workflows/lth-docker.yml@v0.3.0
-#    secrets: inherit
+  liquibase-test-harness:
+    uses: liquibase/build-logic/.github/workflows/lth-docker.yml@DAT-14350
 


### PR DESCRIPTION
chore(lth.yml): update liquibase-test-harness workflow to use a specific version (DAT-14350) of lth-docker.yml for consistency and stability