### PR TITLE
fix: ClassCastExceptions with NoSQL databases

### DIFF
--- a/src/main/java/liquibase/ext/yugabytedb/database/YugabyteDBDatabase.java
+++ b/src/main/java/liquibase/ext/yugabytedb/database/YugabyteDBDatabase.java
@@ -39,6 +39,10 @@ public class YugabyteDBDatabase extends PostgresDatabase {
 
     @Override
     public boolean isCorrectDatabaseImplementation(DatabaseConnection conn) throws DatabaseException {
+        if (!(conn instanceof JdbcConnection)) {
+            return false;
+        }
+
         try (Statement stmt = ((JdbcConnection) conn).createStatement();
              ResultSet rs = stmt.executeQuery("select version()")
         ) {


### PR DESCRIPTION
DatabaseConnection can be a different object than JdbcConnection - for instance, MongoConnection does not extend it. This may cause ClassCastExceptions when running this extension with NoSQL extensions.