### PR TITLE
Fix FoundationalExtensionHarnessSuite (IDs + spock/groovy)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
         <sonar.tests>src/test/groovy</sonar.tests>
         <junit.version>5.11.4</junit.version>
         <junit-platform.version>1.11.4</junit-platform.version>
+        <!-- Pin groovy/spock to versions compatible with liquibase-test-harness 1.0.11,
+             which is built against groovy 4.0.x / spock 2.3-groovy-4.0. The parent POM
+             defaults to groovy 5.0 / spock 2.4-groovy-5.0, which is binary-incompatible
+             (org.spockframework.lang.SpecInternals was moved in spock 2.4). -->
+        <groovy-all.version>4.0.28</groovy-all.version>
+        <spock-core.version>2.3-groovy-4.0</spock-core.version>
     </properties>
 
     <dependencies>

--- a/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/addCheckConstraint.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/addCheckConstraint.sql
@@ -1,1 +1,1 @@
-ALTER TABLE public.posts ADD CONSTRAINT test_check_constraint CHECK (id > 0)
+INVALID TEST -- harness changelog uses pro: namespace which requires liquibase-commercial (not a dependency)

--- a/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/createFunction.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/createFunction.sql
@@ -1,9 +1,1 @@
-CREATE OR REPLACE FUNCTION public.test_function()
-RETURNS trigger
-AS $$
-BEGIN
-RAISE NOTICE 'Test function created'
-RETURN NEW
-END
-$$
-LANGUAGE plpgsql
+INVALID TEST -- harness changelog uses pro: namespace which requires liquibase-commercial (not a dependency)

--- a/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/createPackage.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/createPackage.sql
@@ -1,9 +1,1 @@
-CREATE OR REPLACE FUNCTION test_function()
-RETURNS trigger
-AS $$
-BEGIN
-RAISE NOTICE 'Test function created'
-RETURN NEW
-END
-$$
-LANGUAGE plpgsql
+INVALID TEST -- harness changelog uses pro: namespace which requires liquibase-commercial (not a dependency)

--- a/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/createPackageBody.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/createPackageBody.sql
@@ -1,9 +1,1 @@
-CREATE OR REPLACE FUNCTION test_function()
-RETURNS trigger
-AS $$
-BEGIN
-RAISE NOTICE 'Test function created'
-RETURN NEW
-END
-$$
-LANGUAGE plpgsql
+INVALID TEST -- harness changelog uses pro: namespace which requires liquibase-commercial (not a dependency)

--- a/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/createProcedure.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/createProcedure.sql
@@ -1,6 +1,1 @@
-CREATE OR REPLACE PROCEDURE test_procedure()
-LANGUAGE 'plpgsql'
-AS $$
-BEGIN
-END;
-$$
+INVALID TEST -- procedure snapshot validation requires liquibase-commercial (not a dependency)

--- a/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/createProcedureFromFile.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/createProcedureFromFile.sql
@@ -1,6 +1,1 @@
-CREATE OR REPLACE PROCEDURE test_procedure()
-LANGUAGE 'plpgsql'
-AS $$
-BEGIN
-END;
-$$
+INVALID TEST -- procedure snapshot validation requires liquibase-commercial (not a dependency)

--- a/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/createTrigger.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/createTrigger.sql
@@ -1,12 +1,1 @@
-CREATE OR REPLACE FUNCTION test_function()
-RETURNS trigger
-AS $$
-BEGIN
-RAISE NOTICE 'Test trigger function created'
-RETURN NEW
-END
-$$
-LANGUAGE plpgsql
-CREATE TRIGGER test_trigger
-BEFORE INSERT ON public.posts
-FOR EACH ROW EXECUTE PROCEDURE test_function()
+INVALID TEST -- harness changelog uses pro: namespace which requires liquibase-commercial (not a dependency)

--- a/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/disableTrigger.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/disableTrigger.sql
@@ -1,13 +1,1 @@
-CREATE OR REPLACE FUNCTION test_function()
-RETURNS trigger
-AS $$
-BEGIN
-RAISE NOTICE 'Test trigger function created'
-RETURN NEW
-END
-$$
-LANGUAGE plpgsql
-CREATE TRIGGER test_trigger
-BEFORE INSERT ON public.posts
-FOR EACH ROW EXECUTE PROCEDURE test_function()
-ALTER TABLE public.posts  DISABLE TRIGGER test_trigger
+INVALID TEST -- harness changelog uses pro: namespace which requires liquibase-commercial (not a dependency)

--- a/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/dropCheckConstraint.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/dropCheckConstraint.sql
@@ -1,2 +1,1 @@
-ALTER TABLE public.posts ADD CONSTRAINT test_check_constraint CHECK (id > 0)
-ALTER TABLE public.posts DROP CONSTRAINT test_check_constraint
+INVALID TEST -- harness changelog uses pro: namespace which requires liquibase-commercial (not a dependency)

--- a/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/dropFunction.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/dropFunction.sql
@@ -1,10 +1,1 @@
-CREATE OR REPLACE FUNCTION public.test_function()
-RETURNS trigger
-AS $$
-BEGIN
-RAISE NOTICE 'Test function created'
-RETURN NEW
-END
-$$
-LANGUAGE plpgsql
-DROP FUNCTION public.test_function
+INVALID TEST -- harness changelog uses pro: namespace which requires liquibase-commercial (not a dependency)

--- a/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/dropTrigger.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/dropTrigger.sql
@@ -1,13 +1,1 @@
-CREATE OR REPLACE FUNCTION test_function()
-RETURNS trigger
-AS $$
-BEGIN
-RAISE NOTICE 'Test trigger function created'
-RETURN NEW
-END
-$$
-LANGUAGE plpgsql
-CREATE TRIGGER test_trigger
-BEFORE INSERT ON public.posts
-FOR EACH ROW EXECUTE PROCEDURE test_function()
-DROP TRIGGER test_trigger ON public.posts
+INVALID TEST -- harness changelog uses pro: namespace which requires liquibase-commercial (not a dependency)

--- a/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/enableTrigger.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/enableTrigger.sql
@@ -1,14 +1,1 @@
-CREATE OR REPLACE FUNCTION test_function()
-RETURNS trigger
-AS $$
-BEGIN
-RAISE NOTICE 'Test trigger function created'
-RETURN NEW
-END
-$$
-LANGUAGE plpgsql
-CREATE TRIGGER test_trigger
-BEFORE INSERT ON public.posts
-FOR EACH ROW EXECUTE PROCEDURE test_function()
-ALTER TABLE public.posts  DISABLE TRIGGER test_trigger
-ALTER TABLE public.posts  ENABLE TRIGGER test_trigger
+INVALID TEST -- harness changelog uses pro: namespace which requires liquibase-commercial (not a dependency)

--- a/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/renameTrigger.sql
+++ b/src/test/resources/liquibase/harness/change/expectedSql/yugabytedb/renameTrigger.sql
@@ -1,13 +1,1 @@
-CREATE OR REPLACE FUNCTION test_function()
-RETURNS trigger
-AS $$
-BEGIN
-RAISE NOTICE 'Test trigger function created'
-RETURN NEW
-END
-$$
-LANGUAGE plpgsql
-CREATE TRIGGER test_trigger
-BEFORE INSERT ON public.posts
-FOR EACH ROW EXECUTE PROCEDURE test_function()
-ALTER TRIGGER test_trigger ON public.posts RENAME TO test_trigger_renamed
+INVALID TEST -- harness changelog uses pro: namespace which requires liquibase-commercial (not a dependency)

--- a/src/test/resources/liquibase/harness/compatibility/foundational/expectedResultSet/yugabytedb/createTable.json
+++ b/src/test/resources/liquibase/harness/compatibility/foundational/expectedResultSet/yugabytedb/createTable.json
@@ -14,12 +14,23 @@
     {
       "comments": "test_comment",
       "author": "as",
+      "description": "createTable tableName=test_table_json",
+      "contexts": "test_context",
+      "exectype": "EXECUTED",
+      "labels": "test_label",
+      "filename": "liquibase\/harness\/compatibility\/foundational\/changelogs\/createTable.json",
+      "id": "2",
+      "tag": ""
+    },
+    {
+      "comments": "test_comment",
+      "author": "as",
       "description": "createTable tableName=test_table_yaml",
       "contexts": "test_context",
       "exectype": "EXECUTED",
       "labels": "test_label",
       "filename": "liquibase\/harness\/compatibility\/foundational\/changelogs\/createTable.yml",
-      "id": "1",
+      "id": "3",
       "tag": ""
     },
     {
@@ -30,19 +41,8 @@
       "exectype": "EXECUTED",
       "labels": "test_label",
       "filename": "liquibase\/harness\/compatibility\/foundational\/changelogs\/createTable.sql",
-      "id": "1",
+      "id": "4",
       "tag": "test_tag"
-    },
-    {
-      "comments": "test_comment",
-      "author": "as",
-      "description": "createTable tableName=test_table_json",
-      "contexts": "test_context",
-      "exectype": "EXECUTED",
-      "labels": "test_label",
-      "filename": "liquibase\/harness\/compatibility\/foundational\/changelogs\/createTable.json",
-      "id": "1",
-      "tag": ""
     }
   ]
 }


### PR DESCRIPTION
## Summary

Three fixes get the harness suites running cleanly on this extension again:

### 1. Update expected changeset IDs to match test-harness 1.0.11 (Foundational)
The harness bump 1.0.10 → 1.0.11 (#243) changed the foundational changelogs so each format uses a distinct changeset ID:

| changelog | old id | new id |
|---|---|---|
| createTable.xml  | 1 | 1 |
| createTable.json | 1 | 2 |
| createTable.yml  | 1 | 3 |
| createTable.sql  | 1 | 4 |

`expectedResultSet/yugabytedb/createTable.json` was still asserting `id=1` everywhere, producing the `Unexpected JSON entry` failures reported in #294. The postgresql expected file inside the 1.0.11 JAR was already updated — this just brings the downstream yugabytedb file in line.

### 2. Pin groovy/spock to versions the test-harness was compiled against
The parent-POM bump 1.0.0 → 1.0.2 (#296) raised groovy to 5.0.5 and spock-core to `2.4-groovy-5.0`. But `liquibase-test-harness:1.0.11` is built against groovy 4.0.x and `spock-core:2.3-groovy-4.0`, and Spock 2.4 relocated `org.spockframework.lang.SpecInternals` to `org.spockframework.runtime.SpecInternals`. With the parent defaults the suite fails to discover any test at all:

```
TestEngine with ID 'junit-vintage' failed to discover tests
Caused by: NoClassDefFoundError: org/spockframework/lang/SpecInternals
```

Override `groovy-all.version` and `spock-core.version` in this project's pom.xml until the test-harness publishes a groovy-5.0 build (or the parent POM downgrades).

### 3. Skip Contributed change-tests that require liquibase-commercial
With Spock fixed, the Contributed suite actually runs and surfaces a separate pre-existing problem: the 1.0.11 harness changelogs under `liquibase/harness/change/changelogs/` now use the `pro:` namespace for check constraints, functions, packages, triggers, etc. Parsing them requires `liquibase-commercial`, which this extension does not depend on. Two more changes (`createProcedure`, `createProcedureFromFile`) parse fine but rely on Pro-only snapshot generation for verification.

Mark these 13 change tests as `INVALID TEST` in `expectedSql/yugabytedb/*.sql` so `ChangeObjectTests` aborts via `Assumptions.assumeTrue` (reported as skipped, not failed). This matches the pattern `liquibase-bigquery` uses and the existing `disableCheckConstraint` / `enableCheckConstraint` files in this repo:

```
INVALID TEST -- harness changelog uses pro: namespace which requires liquibase-commercial (not a dependency)
```

Affected: `addCheckConstraint`, `createFunction`, `createPackage`, `createPackageBody`, `createProcedure`, `createProcedureFromFile`, `createTrigger`, `disableTrigger`, `dropCheckConstraint`, `dropFunction`, `dropTrigger`, `enableTrigger`, `renameTrigger`.

Fixes #294

## Test plan
- [ ] CI `Liquibase Test Harness` workflow passes Foundational, Advanced, **and Contributed** on YugabyteDB 2.16 / 2.17
- [ ] `mvn test-compile` succeeds (verified locally with Groovy 4.0.28)