### PR TITLE
Align Groovy/Spock versions with liquibase-test-harness 1.0.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,12 +53,12 @@
         <sonar.tests>src/test/groovy</sonar.tests>
         <junit.version>5.11.4</junit.version>
         <junit-platform.version>1.11.4</junit-platform.version>
-        <!-- Pin groovy/spock to versions compatible with liquibase-test-harness 1.0.11,
-             which is built against groovy 4.0.x / spock 2.3-groovy-4.0. The parent POM
-             defaults to groovy 5.0 / spock 2.4-groovy-5.0, which is binary-incompatible
-             (org.spockframework.lang.SpecInternals was moved in spock 2.4). -->
-        <groovy-all.version>4.0.28</groovy-all.version>
-        <spock-core.version>2.3-groovy-4.0</spock-core.version>
+        <!-- Align groovy/spock with liquibase-test-harness 1.0.12, which is built
+             against groovy 5.0 / spock 2.4-groovy-5.0. The harness specs are compiled
+             against spock 2.4, so an older spock at runtime fails with NoSuchMethodError
+             (e.g. SpecificationContext.setCurrentBlock). -->
+        <groovy-all.version>5.0.6</groovy-all.version>
+        <spock-core.version>2.4-groovy-5.0</spock-core.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
**Problem**

The Spock-based harness suites (FoundationalExtensionHarnessSuite, AdvancedExtensionHarnessSuite) fail at runtime with:
java.lang.NoSuchMethodError: 'void org.spockframework.runtime.SpecificationContext.setCurrentBlock(org.spockframework.runtime.model.BlockInfo)'

liquibase-test-harness was upgraded to 1.0.12, whose compiled specs are built against Spock 2.4-groovy-5.0 / Groovy 5.0.6. However the pom still forced Spock 2.3-groovy-4.0 / Groovy 4.0.28, so setCurrentBlock(...) (a Spock 2.4 method) is missing at runtime.

**Fix**

Align the Groovy/Spock versions with what harness 1.0.12 expects:
  - groovy-all.version: 4.0.28 → 5.0.6
  - spock-core.version: 2.3-groovy-4.0 → 2.4-groovy-5.0

**Verification**

Built with JDK 17 against a local YugabyteDB cluster — both suites pass:
  - FoundationalExtensionHarnessSuite: 2/2 ✅
  - AdvancedExtensionHarnessSuite: 9/9 ✅