### PR TITLE
ci: label Dependabot PRs with sdou to pass required-labels check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "sdou"
 
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "sdou"
 


### PR DESCRIPTION
Dependabot PRs got the `dependencies` label, which `label-pr.yml` doesn't accept, so the required-labels check failed on every bump.

Add `labels: ["sdou"]` to both update entries — `sdou` passes the check and is already handled by release-drafter. Matches `liquibase-redshift`/`dynamodb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
