### PR TITLE
build: align JUnit modules under a single 6.1.2 version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
     <properties>
         <liquibase.version>5.0.3</liquibase.version>
         <sonar.tests>src/test/groovy</sonar.tests>
-        <junit.version>5.11.4</junit.version>
-        <junit-platform.version>1.11.4</junit-platform.version>
+        <!-- JUnit 6+ aligns all modules (jupiter, vintage, platform) under one version. -->
+        <junit.version>6.1.2</junit.version>
         <!-- Align groovy/spock with liquibase-test-harness 1.0.12, which is built
              against groovy 5.0 / spock 2.4-groovy-5.0. The harness specs are compiled
              against spock 2.4, so an older spock at runtime fails with NoSuchMethodError
@@ -110,13 +110,13 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite</artifactId>
-            <version>${junit-platform.version}</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
-            <version>${junit-platform.version}</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
JUnit 6 aligned all module versions (jupiter, vintage, platform), which were previously split across the `5.x` and `1.x` schemes.

Collapse `junit-platform.version` into a single `junit.version` (6.1.2) so all five JUnit artifacts stay aligned on future bumps. Verified with `mvn test-compile` (BUILD SUCCESS).

Supersedes #314 and #315, which each bumped only one property and left the versions mismatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
